### PR TITLE
mads: remove unnecessary super init in MadsCarController (#197)

### DIFF
--- a/opendbc/sunnypilot/car/hyundai/mads.py
+++ b/opendbc/sunnypilot/car/hyundai/mads.py
@@ -24,7 +24,6 @@ MadsDataSP = namedtuple("MadsDataSP",
 
 class MadsCarController:
   def __init__(self):
-    super().__init__()
     self.mads = MadsDataSP(False, False, False, False)
 
     self.lat_disengage_blink = 0


### PR DESCRIPTION
- Cleans up redundant `super().__init__()` call.

<!--
We need these details to verify your pull request.

Find your device's dongle ID and a route at https://connect.comma.ai.
Ideally, the route is recorded with the exact branch of your pull request.
-->
Validation
* Dongle ID: 
* Route: 
